### PR TITLE
Update repo references to human-ai-evolution

### DIFF
--- a/commands/advanced.md
+++ b/commands/advanced.md
@@ -201,7 +201,7 @@ Claude: 📝 Creating Enhancement Proposal:
         Solution: Automatic checkpoint every 10 minutes
         Impact: Minimal overhead, high safety value
         
-        Creating PR: github.com/omar-el-mountassir/claude-framework/pull/1
+        Creating PR: github.com/omar-el-mountassir/human-ai-evolution/pull/1
         
         🎯 Review and merge to activate this enhancement.
 ```
@@ -239,7 +239,7 @@ Claude: 📌 Framework Version: 2.2.5
         - v2.2.4: Implemented command system
         - v2.2.3: Added prioritized decisions
         
-        Repository: github.com/omar-el-mountassir/claude-framework
+        Repository: github.com/omar-el-mountassir/human-ai-evolution
         Last Updated: 2024-01-13
         
         💡 Use `/propose` to suggest improvements.

--- a/framework.md
+++ b/framework.md
@@ -256,7 +256,7 @@ This framework evolves through use. When patterns emerge or friction is detected
 4. **Version Update**: Approved changes create new framework version
 5. **Rollback Capability**: All versions maintained in git history
 
-**GitHub Repository**: github.com/omar-el-mountassir/claude-framework
+**GitHub Repository**: github.com/omar-el-mountassir/human-ai-evolution
 
 ## The Prime Directive [FINAL VERSION]
 


### PR DESCRIPTION
## Summary
- update docs to reference `human-ai-evolution` repository path

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684c2a5a3a6c8333bcd0333fdafedac6

## Summary by Sourcery

Update documentation to replace old repository path references with the new "human-ai-evolution" repository

Documentation:
- Update repository URL in commands/advanced.md to point to human-ai-evolution
- Update GitHub repository link in framework.md to reference human-ai-evolution